### PR TITLE
Import cadquery as cq

### DIFF
--- a/plugins/sample_plugin/__init__.py
+++ b/plugins/sample_plugin/__init__.py
@@ -1,5 +1,5 @@
-from cadquery import *
+import cadquery as cq
 from .sample_plugin import make_cubes
 
 # Link the plugin in
-Workplane.make_cubes = make_cubes
+cq.Workplane.make_cubes = make_cubes

--- a/plugins/sample_plugin/sample_plugin.py
+++ b/plugins/sample_plugin/sample_plugin.py
@@ -1,10 +1,10 @@
-from cadquery import *
+import cadquery as cq
 
 def make_cubes(self, length):
     # self refers to the CQ or Workplane object
 
     # create the solid
-    s = Solid.makeBox(length, length, length, Vector(0, 0, 0))
+    s = cq.Solid.makeBox(length, length, length, cq.Vector(0, 0, 0))
 
-    # use CQ utility method to iterate over the stack an position the cubes
+    # use CQ utility method to iterate over the stack and position the cubes
     return self.eachpoint(lambda loc: s.located(loc), True)


### PR DESCRIPTION
@jmwright, do you mind if we change the example to not encourage `from cadquery import *`? It can cause some problems like namespace collisions and drives a lot of linters crazy (mine included).