### PR TITLE
Moved from inspect.getsource() to hash()

### DIFF
--- a/plugins/cq_cache/cq_cache.py
+++ b/plugins/cq_cache/cq_cache.py
@@ -109,10 +109,10 @@ def using_same_function(fct, file_name):
     It assure that if the function has been modify, the cache won't load a wrong cached file
     """
     with open(file_name, "r") as f:
-        cached_function = "".join(f.readlines()[:-1])
+        cached_function_hash = int(f.readlines()[0])
 
-    caching_function = inspect.getsource(fct)
-    if cached_function == caching_function:
+    caching_function_hash = hash(fct)
+    if cached_function_hash == caching_function_hash:
         return True
     else:
         return False
@@ -182,7 +182,8 @@ def cq_cache(cache_size=500):
                 )
 
                 with open(os.path.join(CACHE_DIR_PATH, file_name), "w") as fun_file:
-                    fun_file.write(inspect.getsource(function))
+                    fun_file.write(str(hash(function)))
+                    fun_file.write("\n")
                     fun_file.write(shape_type.__name__)
 
                 cache_dir_size = get_cache_dir_size(CACHE_DIR_PATH)

--- a/plugins/cq_cache/setup.py
+++ b/plugins/cq_cache/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "1.0.0"  # Please update this version number when updating the plugin
+version = "1.0.1"  # Please update this version number when updating the plugin
 plugin_name = "cq_cache"
 description = "File based cache decorator"
 long_description = "Allow to use file based cache to not have to rebuild every cadquery model from scratch"


### PR DESCRIPTION
Since the plugin was failing in cq-editor due to how cq-editor executes code, I removed the inspect.getsource() used to instead hash the function that is decorated.

It now works in cq-editor aswell