### PR TITLE
Add cq_gears to the list of 3rd party plugins

### DIFF
--- a/third_party.md
+++ b/third_party.md
@@ -14,4 +14,4 @@ If you are interested in having a plugin included in this list, it must meet the
 
 | Plugin Name    | Category     | Link        | Description      | Author      |
 | :------------- | :----------- | :---------- | :--------------- | :---------- |
-No Plugins Listed At This Time
+| cq_gears       | Modeling     | [README](https://github.com/meadiode/cq_gears/blob/main/README.md) |Parametric involute profile gear generator |[meadiode](https://github.com/meadiode)|


### PR DESCRIPTION
#1 
A plugin/extension to generate involute profile gears. Check it out here: https://github.com/meadiode/cq_gears
