### PR TITLE
Plugin for local coordinate system selectors

### DIFF
--- a/plugins/localselectors/README.md
+++ b/plugins/localselectors/README.md
@@ -1,0 +1,46 @@
+# Sample Plugin
+
+[Provide a short description of your plugin here.]
+
+This sample plugin gives an example of how to build a plugin that is installable from this repository. Once installed, it should be possible to import the plugin, making its `make_cubes` function available for use as if it was part of the `cadquery.Workplane` class.
+
+## Installation
+
+[How does a user install your plugin?]
+
+It is possible to install individual plugins from this repository, as long as the plugin has a valid `setup.py`. If you copied the `sampleplugin` directory, it has a starter `setup.py` file in it.
+
+Installation takes form:
+
+```
+pip install -e "git+https://github.com/CadQuery/cadquery-plugins.git#egg=[your_plugin_name]&subdirectory=[your_plugin_subdirectory]"
+```
+
+To install this sample plugin, the following line should be used.
+
+```
+pip install -e "git+https://github.com/CadQuery/cadquery-plugins.git#egg=sampleplugin&subdirectory=plugins/sampleplugin"
+```
+
+## Dependencies
+
+[Are there any other dependencies that need to be installed for your plugin to work?]
+
+[Is there anything else that is different about your plugin that the user needs to know?]
+
+This sample plugin has no dependencies other than the cadquery library. To install CadQuery, follow the [instructions in its readme](https://github.com/CadQuery/cadquery#getting-started).
+
+## Usage
+
+[Place descriptions and examples of how to use your plugin here.]
+
+To use this plugin after it has been installed, import it to automatically patch its function(s) into the `cadquery.Workplane` class. The `make_cubes` function should be available after import, but be sure to import `cadquery` first.
+
+```python
+import cadquery as cq
+import sampleplugin # Adds the make_cubes function to cadquery.Workplane
+
+result = (cq.Workplane().rect(50, 50, forConstruction=True)
+                        .vertices()
+                        .make_cubes(10))
+```

--- a/plugins/localselectors/README.md
+++ b/plugins/localselectors/README.md
@@ -1,46 +1,37 @@
 # Sample Plugin
 
-[Provide a short description of your plugin here.]
-
-This sample plugin gives an example of how to build a plugin that is installable from this repository. Once installed, it should be possible to import the plugin, making its `make_cubes` function available for use as if it was part of the `cadquery.Workplane` class.
+This plugin modifies `Workplane` selectors so that they can be used to specify axes in the local coordinate place.
+This is done by using the lowercase letters `x`, `y`, and `z` instead of the uppercase ones.
 
 ## Installation
 
-[How does a user install your plugin?]
-
-It is possible to install individual plugins from this repository, as long as the plugin has a valid `setup.py`. If you copied the `sampleplugin` directory, it has a starter `setup.py` file in it.
-
-Installation takes form:
-
 ```
-pip install -e "git+https://github.com/CadQuery/cadquery-plugins.git#egg=[your_plugin_name]&subdirectory=[your_plugin_subdirectory]"
+pip install -e "git+https://github.com/CadQuery/cadquery-plugins.git#egg=localcoordinates&subdirectory=plugins/localcoordinates"
 ```
 
-To install this sample plugin, the following line should be used.
-
-```
-pip install -e "git+https://github.com/CadQuery/cadquery-plugins.git#egg=sampleplugin&subdirectory=plugins/sampleplugin"
-```
 
 ## Dependencies
 
-[Are there any other dependencies that need to be installed for your plugin to work?]
-
-[Is there anything else that is different about your plugin that the user needs to know?]
-
-This sample plugin has no dependencies other than the cadquery library. To install CadQuery, follow the [instructions in its readme](https://github.com/CadQuery/cadquery#getting-started).
+This plugin has no dependencies other than the cadquery library. To install CadQuery, follow the [instructions in its readme](https://github.com/CadQuery/cadquery#getting-started).
+It uses a lot of internal structures, so it may break more easily on later versions of CadQuery more easily than other plugins.
+It was tested on CadQuery 2.5, feel free to post an issue in my [fork](https://github.com/cactorium/cadquery-plugins) if you run into any issues
 
 ## Usage
 
-[Place descriptions and examples of how to use your plugin here.]
-
-To use this plugin after it has been installed, import it to automatically patch its function(s) into the `cadquery.Workplane` class. The `make_cubes` function should be available after import, but be sure to import `cadquery` first.
+To use this plugin after it has been installed, import it to automatically patch its function(s) into the `cadquery.Workplane` class. Any function that uses string selectors should now work with these new selectors after import, but be sure to import `cadquery` first.
 
 ```python
 import cadquery as cq
-import sampleplugin # Adds the make_cubes function to cadquery.Workplane
 
-result = (cq.Workplane().rect(50, 50, forConstruction=True)
-                        .vertices()
-                        .make_cubes(10))
+result = (cq.Workplane().rect(50, 50)
+                        .extrude(50))
+
+new_workplane = (result.faces(">x") # this should be the same as '>x'
+                        .workplane())
+result2 = (new_workplane.rect(30, 30)
+           .extrude(30))
+
+new_workplane = (result2
+            .faces(">z")
+            .workplane()) # this should be the face sticking away from the first cube
 ```

--- a/plugins/localselectors/README.md
+++ b/plugins/localselectors/README.md
@@ -26,7 +26,7 @@ import cadquery as cq
 result = (cq.Workplane().rect(50, 50)
                         .extrude(50))
 
-new_workplane = (result.faces(">x") # this should be the same as '>x'
+new_workplane = (result.faces(">x") # this should be the same as '>X' because we're starting off in the default coordinate system
                         .workplane())
 result2 = (new_workplane.rect(30, 30)
            .extrude(30))

--- a/plugins/localselectors/localselectors.py
+++ b/plugins/localselectors/localselectors.py
@@ -19,6 +19,7 @@ from pyparsing import (
     opAssoc,
 )
 
+
 def _makeGrammar():
     """
     Define the simple string selector grammar using PyParsing
@@ -41,7 +42,9 @@ def _makeGrammar():
     )
 
     # direction definition
-    simple_dir = oneOf(["X", "Y", "Z", "XY", "XZ", "YZ"] + ["x", "y", "z", "xy", "xz", "yz"])
+    simple_dir = oneOf(
+        ["X", "Y", "Z", "XY", "XZ", "YZ"] + ["x", "y", "z", "xy", "xz", "yz"]
+    )
     direction = simple_dir("simple_dir") | vector("vector_dir")
 
     # CQ type definition
@@ -84,11 +87,14 @@ def _makeGrammar():
 
 old_getVector = cq.selectors._SimpleStringSyntaxSelector._getVector
 
+
 def _getVector(self, pr):
-    if "simple_dir" in pr and  pr.simple_dir in cq.selectors._SimpleStringSyntaxSelector.local_axes:
+    if ("simple_dir" in pr and
+            pr.simple_dir in cq.selectors._SimpleStringSyntaxSelector.local_axes):
         return cq.selectors._SimpleStringSyntaxSelector.local_axes[pr.simple_dir]
     else:
         return old_getVector(self, pr)
+
 
 class LocalCoordinates:
     def __init__(self, plane):
@@ -96,7 +102,8 @@ class LocalCoordinates:
         self.old_axes = None
 
     def __enter__(self):
-        self.old_axes, cq.selectors._SimpleStringSyntaxSelector.local_axes = (cq.selectors._SimpleStringSyntaxSelector.local_axes, 
+        self.old_axes, cq.selectors._SimpleStringSyntaxSelector.local_axes = (
+            cq.selectors._SimpleStringSyntaxSelector.local_axes, 
             {
                 'x': self.plane.xDir,
                 'y': self.plane.yDir,
@@ -104,7 +111,8 @@ class LocalCoordinates:
                 'xy': self.plane.xDir + self.plane.yDir,
                 'yz': self.plane.yDir + self.plane.zDir,
                 'xz': self.plane.xDir + self.plane.zDir,
-            })
+            },
+        )
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
         cq.selectors._SimpleStringSyntaxSelector.local_axes = self.old_axes
@@ -125,16 +133,18 @@ def _filter(self, objs, selector):
     return toReturn
 
 cq.selectors._SimpleStringSyntaxSelector.local_axes = {
-        "x": Vector(1, 0, 0),
-        "y": Vector(0, 1, 0),
-        "z": Vector(0, 0, 1),
-        "xy": Vector(1, 1, 0),
-        "yz": Vector(0, 1, 1),
-        "xz": Vector(1, 0, 1),
+    "x": Vector(1, 0, 0),
+    "y": Vector(0, 1, 0),
+    "z": Vector(0, 0, 1),
+    "xy": Vector(1, 1, 0),
+    "yz": Vector(0, 1, 1),
+    "xz": Vector(1, 0, 1),
 }
 cq.selectors._SimpleStringSyntaxSelector._getVector = _getVector
 
 cq.selectors._grammar = _makeGrammar()  # make a grammar instance
-cq.selectors._expression_grammar = cq.selectors._makeExpressionGrammar(cq.selectors._grammar)
+cq.selectors._expression_grammar = cq.selectors._makeExpressionGrammar(
+    cq.selectors._grammar
+)
 
 cq.Workplane._filter = _filter

--- a/plugins/localselectors/localselectors.py
+++ b/plugins/localselectors/localselectors.py
@@ -49,8 +49,7 @@ def _makeGrammar():
 
     # CQ type definition
     cqtype = oneOf(
-        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()),
-        caseless=True,
+        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
     )
     cqtype = cqtype.setParseAction(pyparsing_common.upcaseTokens)
 

--- a/plugins/localselectors/localselectors.py
+++ b/plugins/localselectors/localselectors.py
@@ -49,7 +49,8 @@ def _makeGrammar():
 
     # CQ type definition
     cqtype = oneOf(
-        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
+        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()),
+        caseless=True,
     )
     cqtype = cqtype.setParseAction(pyparsing_common.upcaseTokens)
 
@@ -89,8 +90,10 @@ old_getVector = cq.selectors._SimpleStringSyntaxSelector._getVector
 
 
 def _getVector(self, pr):
-    if ("simple_dir" in pr and
-            pr.simple_dir in cq.selectors._SimpleStringSyntaxSelector.local_axes):
+    if (
+        "simple_dir" in pr
+        and pr.simple_dir in cq.selectors._SimpleStringSyntaxSelector.local_axes
+    ):
         return cq.selectors._SimpleStringSyntaxSelector.local_axes[pr.simple_dir]
     else:
         return old_getVector(self, pr)
@@ -103,14 +106,14 @@ class LocalCoordinates:
 
     def __enter__(self):
         self.old_axes, cq.selectors._SimpleStringSyntaxSelector.local_axes = (
-            cq.selectors._SimpleStringSyntaxSelector.local_axes, 
+            cq.selectors._SimpleStringSyntaxSelector.local_axes,
             {
-                'x': self.plane.xDir,
-                'y': self.plane.yDir,
-                'z': self.plane.zDir,
-                'xy': self.plane.xDir + self.plane.yDir,
-                'yz': self.plane.yDir + self.plane.zDir,
-                'xz': self.plane.xDir + self.plane.zDir,
+                "x": self.plane.xDir,
+                "y": self.plane.yDir,
+                "z": self.plane.zDir,
+                "xy": self.plane.xDir + self.plane.yDir,
+                "yz": self.plane.yDir + self.plane.zDir,
+                "xz": self.plane.xDir + self.plane.zDir,
             },
         )
 
@@ -131,6 +134,7 @@ def _filter(self, objs, selector):
         toReturn = objs
 
     return toReturn
+
 
 cq.selectors._SimpleStringSyntaxSelector.local_axes = {
     "x": Vector(1, 0, 0),

--- a/plugins/localselectors/localselectors.py
+++ b/plugins/localselectors/localselectors.py
@@ -1,0 +1,241 @@
+import cadquery as cq
+
+from cadquery.occ_impl.geom import Vector
+from cadquery.occ_impl.shape_protocols import (
+    geom_LUT_EDGE,
+    geom_LUT_FACE,
+    ShapeProtocol
+)
+
+from pyparsing import (
+    pyparsing_common,
+    Literal,
+    Word,
+    nums,
+    Optional,
+    Combine,
+    oneOf,
+    Group,
+    infixNotation,
+    opAssoc,
+)
+
+from functools import reduce
+from typing import Iterable, List, Sequence, TypeVar, cast
+
+Shape = TypeVar("Shape", bound=ShapeProtocol)
+
+def _makeGrammar():
+    """
+    Define the simple string selector grammar using PyParsing
+    """
+
+    # float definition
+    point = Literal(".")
+    plusmin = Literal("+") | Literal("-")
+    number = Word(nums)
+    integer = Combine(Optional(plusmin) + number)
+    floatn = Combine(integer + Optional(point + Optional(number)))
+
+    # vector definition
+    lbracket = Literal("(")
+    rbracket = Literal(")")
+    comma = Literal(",")
+    vector = Combine(
+        lbracket + floatn("x") + comma + floatn("y") + comma + floatn("z") + rbracket,
+        adjacent=False,
+    )
+
+    # direction definition
+    simple_dir = oneOf(["X", "Y", "Z", "XY", "XZ", "YZ"] + ["x", "y", "z", "xy", "xz", "yz"])
+    direction = simple_dir("simple_dir") | vector("vector_dir")
+
+    # CQ type definition
+    cqtype = oneOf(
+        set(geom_LUT_EDGE.values()) | set(geom_LUT_FACE.values()), caseless=True,
+    )
+    cqtype = cqtype.setParseAction(pyparsing_common.upcaseTokens)
+
+    # type operator
+    type_op = Literal("%")
+
+    # direction operator
+    direction_op = oneOf([">", "<"])
+
+    # center Nth operator
+    center_nth_op = oneOf([">>", "<<"])
+
+    # index definition
+    ix_number = Group(Optional("-") + Word(nums))
+    lsqbracket = Literal("[").suppress()
+    rsqbracket = Literal("]").suppress()
+
+    index = lsqbracket + ix_number("index") + rsqbracket
+
+    # other operators
+    other_op = oneOf(["|", "#", "+", "-"])
+
+    # named view
+    named_view = oneOf(["front", "back", "left", "right", "top", "bottom"])
+
+    return (
+        direction("only_dir")
+        | (type_op("type_op") + cqtype("cq_type"))
+        | (direction_op("dir_op") + direction("dir") + Optional(index))
+        | (center_nth_op("center_nth_op") + direction("dir") + Optional(index))
+        | (other_op("other_op") + direction("dir"))
+        | named_view("named_view")
+    )
+
+
+cq.selectors._grammar = _makeGrammar()  # make a grammar instance
+
+class _SimpleStringSyntaxSelector(cq.Selector):
+    """
+    This is a private class that converts a parseResults object into a simple
+    selector object
+    """
+
+    # moved out here so I can hackishly change them at run time
+    axes = {
+        "X": Vector(1, 0, 0),
+        "Y": Vector(0, 1, 0),
+        "Z": Vector(0, 0, 1),
+        "XY": Vector(1, 1, 0),
+        "YZ": Vector(0, 1, 1),
+        "XZ": Vector(1, 0, 1),
+        "x": Vector(1, 0, 0),
+        "y": Vector(0, 1, 0),
+        "z": Vector(0, 0, 1),
+        "xy": Vector(1, 1, 0),
+        "yz": Vector(0, 1, 1),
+        "xz": Vector(1, 0, 1),
+    }
+    def __init__(self, parseResults):
+
+        # define all token to object mappings
+
+        self.namedViews = {
+            "front": (Vector(0, 0, 1), True),
+            "back": (Vector(0, 0, 1), False),
+            "left": (Vector(1, 0, 0), False),
+            "right": (Vector(1, 0, 0), True),
+            "top": (Vector(0, 1, 0), True),
+            "bottom": (Vector(0, 1, 0), False),
+        }
+
+        self.operatorMinMax = {
+            ">": True,
+            ">>": True,
+            "<": False,
+            "<<": False,
+        }
+
+        self.operator = {
+            "+": cq.selectors.DirectionSelector,
+            "-": lambda v: cq.selectors.DirectionSelector(-v),
+            "#": cq.selectors.PerpendicularDirSelector,
+            "|": cq.selectors.ParallelDirSelector,
+        }
+
+        self.parseResults = parseResults
+        self.mySelector = self._chooseSelector(parseResults)
+
+    def _chooseSelector(self, pr):
+        """
+        Sets up the underlying filters accordingly
+        """
+        if "only_dir" in pr:
+            vec = self._getVector(pr)
+            return cq.selectors.DirectionSelector(vec)
+
+        elif "type_op" in pr:
+            return cq.selectors.TypeSelector(pr.cq_type)
+
+        elif "dir_op" in pr:
+            vec = self._getVector(pr)
+            minmax = self.operatorMinMax[pr.dir_op]
+
+            if "index" in pr:
+                return cq.selectors.DirectionNthSelector(
+                    vec, int("".join(pr.index.asList())), minmax
+                )
+            else:
+                return cq.selectors.DirectionMinMaxSelector(vec, minmax)
+
+        elif "center_nth_op" in pr:
+            vec = self._getVector(pr)
+            minmax = self.operatorMinMax[pr.center_nth_op]
+
+            if "index" in pr:
+                return cq.selectors.CenterNthSelector(vec, int("".join(pr.index.asList())), minmax)
+            else:
+                return cq.selectors.CenterNthSelector(vec, -1, minmax)
+
+        elif "other_op" in pr:
+            vec = self._getVector(pr)
+            return self.operator[pr.other_op](vec)
+
+        else:
+            args = self.namedViews[pr.named_view]
+            return cq.selectors.DirectionMinMaxSelector(*args)
+
+    def _getVector(self, pr):
+        """
+        Translate parsed vector string into a CQ Vector
+        """
+        if "vector_dir" in pr:
+            vec = pr.vector_dir
+            return Vector(float(vec.x), float(vec.y), float(vec.z))
+        else:
+            return _SimpleStringSyntaxSelector.axes[pr.simple_dir]
+
+    def filter(self, objectList: Sequence[Shape]):
+        r"""
+        selects minimum, maximum, positive or negative values relative to a direction
+        ``[+|-|<|>|] <X|Y|Z>``
+        """
+        return self.mySelector.filter(objectList)
+cq.selectors._SimpleStringSyntaxSelector = _SimpleStringSyntaxSelector
+cq.selectors._expression_grammar = cq.selectors._makeExpressionGrammar(cq.selectors._grammar)
+
+class LocalCoordinates:
+    def __init__(self, plane):
+        self.plane = plane
+        self.old_axes = None
+
+    def __enter__(self):
+        self.old_axes = {d:_SimpleStringSyntaxSelector.axes[d] for d in ['x', 'y', 'z', 'xy', 'xz', 'yz']}
+        new_axes = {
+            'x': self.plane.xDir,
+            'y': self.plane.yDir,
+            'z': self.plane.zDir,
+            'xy': self.plane.xDir + self.plane.yDir,
+            'yz': self.plane.yDir + self.plane.zDir,
+            'xz': self.plane.xDir + self.plane.zDir,
+        }
+        for d, v in new_axes.items():
+            _SimpleStringSyntaxSelector.axes[d] = v
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        for d, v in self.old_axes.items():
+            _SimpleStringSyntaxSelector.axes[d] = v
+
+
+def _filter(self, objs, selector):
+    print("debug")
+    # TODO adjust _SimpleStringSyntaxSelector.axes
+    selectorObj: Selector
+    if selector:
+        if isinstance(selector, str):
+            with LocalCoordinates(self.plane):
+                selectorObj = cq.selectors.StringSyntaxSelector(selector)
+        else:
+            selectorObj = selector
+        toReturn = selectorObj.filter(objs)
+    else:
+        toReturn = objs
+
+    return toReturn
+
+cq.Workplane._filter = _filter

--- a/plugins/localselectors/setup.py
+++ b/plugins/localselectors/setup.py
@@ -1,0 +1,49 @@
+from setuptools import setup, find_packages
+
+# Change these variables to set the information for your plugin
+version = "1.0.0"  # Please update this version number when updating the plugin
+plugin_name = "localselectors"  # The name of your plugin
+description = "Adds local coordinator selectors to CadQuery"
+long_description = "Monkey patches in local coordinate selectors so you can use things like '>x'"
+author = "Kelvin Ly"
+author_email = "cactorium"
+packages = []  # List of packages that will be installed with this plugin
+py_modules = ["localselectors"]  # Put the name of your plugin's .py file here
+install_requires = (
+    []
+)  # Any dependencies that pip also needs to install to make this plugin work
+
+
+setup(
+    name=plugin_name,
+    version=version,
+    url="https://github.com/CadQuery/cadquery-plugins",
+    license="Apache Public License 2.0",
+    author=author,
+    author_email=author_email,
+    description=description,
+    long_description=long_description,
+    packages=packages,
+    py_modules=py_modules,
+    install_requires=install_requires,
+    include_package_data=True,
+    zip_safe=False,
+    platforms="any",
+    test_suite="tests",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: POSIX",
+        "Operating System :: MacOS",
+        "Operating System :: Unix",
+        "Programming Language :: Python",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Internet",
+        "Topic :: Scientific/Engineering",
+    ],
+)

--- a/plugins/localselectors/setup.py
+++ b/plugins/localselectors/setup.py
@@ -4,7 +4,9 @@ from setuptools import setup, find_packages
 version = "1.0.0"  # Please update this version number when updating the plugin
 plugin_name = "localselectors"  # The name of your plugin
 description = "Adds local coordinator selectors to CadQuery"
-long_description = "Monkey patches in local coordinate selectors so you can use things like '>x'"
+long_description = (
+    "Monkey patches in local coordinate selectors so you can use things like '>x'"
+)
 author = "Kelvin Ly"
 author_email = "cactorium"
 packages = []  # List of packages that will be installed with this plugin


### PR DESCRIPTION
This adds a new plugin that adds 3 new axes to use in selectors, the local X, Y, and Z. It's pretty intrusive on how it monkey patches than how I'd like, and basically uses globals to inject the local axis vectors into the string selector parsing logic, so please let me know if you guys think there's a better way to do it